### PR TITLE
badge now only reflects status of upstream master

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Unity - Test runner
 
-[![Actions status](https://github.com/webbertakken/unity-test-runner/workflows/Actions%20%F0%9F%98%8E/badge.svg)](https://github.com/webbertakken/unity-test-runner/actions?query=branch%3Amaster+workflow%3A%22Actions+%F0%9F%98%8E%22)
+[![Actions status](https://github.com/webbertakken/unity-test-runner/workflows/Actions%20%F0%9F%98%8E/badge.svg?event=push&branch=master)](https://github.com/webbertakken/unity-test-runner/actions?query=branch%3Amaster+event%3Apush+workflow%3A"Actions%20%F0%9F%98%8E")
 
 ---
 


### PR DESCRIPTION
Relates to https://github.com/webbertakken/unity-actions/issues/33