### PR TITLE
Editor log now saves to artifacts folder

### DIFF
--- a/action/steps/run_tests.sh
+++ b/action/steps/run_tests.sh
@@ -77,12 +77,15 @@ if [ $EDIT_MODE = true ]; then
   xvfb-run --auto-servernum --server-args='-screen 0 640x480x24' \
     /opt/Unity/Editor/Unity \
       -batchmode \
-      -logfile /dev/stdout \
+      -logFile "$FULL_ARTIFACTS_PATH/editmode.log" \
       -projectPath "$UNITY_PROJECT_PATH" \
       -runTests \
       -testPlatform editmode \
       -testResults "$FULL_ARTIFACTS_PATH/editmode-results.xml" \
       $CUSTOM_PARAMETERS
+
+  # Print unity log output
+  cat "$FULL_ARTIFACTS_PATH/editmode.log"
 
   # Catch exit code
   EDIT_MODE_EXIT_CODE=$?
@@ -112,12 +115,15 @@ if [ $PLAY_MODE = true ]; then
   xvfb-run --auto-servernum --server-args='-screen 0 640x480x24' \
     /opt/Unity/Editor/Unity \
       -batchmode \
-      -logfile /dev/stdout \
+      -logFile "$FULL_ARTIFACTS_PATH/playmode.log" \
       -projectPath "$UNITY_PROJECT_PATH" \
       -runTests \
       -testPlatform playmode \
       -testResults "$FULL_ARTIFACTS_PATH/playmode-results.xml" \
       $CUSTOM_PARAMETERS
+
+  # Print unity log output
+  cat "$FULL_ARTIFACTS_PATH/playmode.log"
 
   # Catch exit code
   PLAY_MODE_EXIT_CODE=$?


### PR DESCRIPTION
## Why it's important

- It allows user to easily download Editor.log file without Github Actions/License/Command Line messages. Makes a search of errors a little convenient.

- It makes possible to use [Unity Test Runner Results Reporter](https://github.com/Unity-Technologies/UnityTestRunnerResultsReporter) which can generate html report from .xml report and log