### PR TITLE
Fixed always passing action

### DIFF
--- a/action/steps/run_tests.sh
+++ b/action/steps/run_tests.sh
@@ -83,12 +83,12 @@ if [ $EDIT_MODE = true ]; then
       -testPlatform editmode \
       -testResults "$FULL_ARTIFACTS_PATH/editmode-results.xml" \
       $CUSTOM_PARAMETERS
-
-  # Print unity log output
-  cat "$FULL_ARTIFACTS_PATH/editmode.log"
-
+      
   # Catch exit code
   EDIT_MODE_EXIT_CODE=$?
+  
+  # Print unity log output
+  cat "$FULL_ARTIFACTS_PATH/editmode.log"
 
   # Display results
   if [ $EDIT_MODE_EXIT_CODE -eq 0 ]; then
@@ -121,12 +121,12 @@ if [ $PLAY_MODE = true ]; then
       -testPlatform playmode \
       -testResults "$FULL_ARTIFACTS_PATH/playmode-results.xml" \
       $CUSTOM_PARAMETERS
+      
+  # Catch exit code
+  PLAY_MODE_EXIT_CODE=$?
 
   # Print unity log output
   cat "$FULL_ARTIFACTS_PATH/playmode.log"
-
-  # Catch exit code
-  PLAY_MODE_EXIT_CODE=$?
 
   # Display results
   if [ $PLAY_MODE_EXIT_CODE -eq 0 ]; then


### PR DESCRIPTION
Fixing bug caused by my previous PR.
Because of the wrong order `EDIT_MODE_EXIT_CODE=$?` was returning not Unity exit code, but `cat` exit code (which always was correct even if tests failed). Check reports [before fix](https://github.com/Macoron/unity-test-runner/runs/444568354) and [after fix](https://github.com/Macoron/unity-test-runner/runs/446883829).