### PR TITLE
Add intructions for debugging

### DIFF
--- a/action/entrypoint.sh
+++ b/action/entrypoint.sh
@@ -9,6 +9,23 @@ source /steps/run_tests.sh
 source /steps/return_license.sh
 
 #
+# Instructions for debugging
+#
+
+if [[ $TEST_RUNNER_EXIT_CODE -gt 0 ]]; then
+echo ""
+echo "###########################"
+echo "#         Failure         #"
+echo "###########################"
+echo ""
+echo "Please note that the exit code is not very descriptive."
+echo "Most likely it will not help you solve the issue."
+echo ""
+echo "To find the reason for failure: please search for errors in the log above."
+echo ""
+fi;
+
+#
 # Exit with code from the build step.
 #
 


### PR DESCRIPTION
#### Changes

This adds a self-help message

It is meant to prevent getting messages like this on discord and in issues multiple times a week:

> Hi i have error
> ```
> Unity exited with code XX
> ```
> I think it's a bug because i did everything correctly.

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)