### PR TITLE
Add all parameters to action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,24 @@ inputs:
     required: false
     default: '2019.2.11f1'
     description: 'Version of unity to use for testing the project.'
+  projectPath:
+    required: false
+    description: 'Path to the Unity project to be tested.'
+  testMode:
+    required: false
+    default: 'all'
+    description: 'The type of tests to be run by the test runner.'
+  artifactsPath:
+    required: false
+    default: 'artifacts'
+    description: 'Path where test results should be stored.'
+  useNetworkHost:
+    required: false
+    default: false
+    description: 'Initialzes Docker using the network host.'
+  customParameters:
+    required: false
+    description: 'Custom parameters to configure the test runner.'
 outputs:
   artifactsPath:
     description: 'Path where the artifacts are stored'

--- a/action.yml
+++ b/action.yml
@@ -16,14 +16,14 @@ inputs:
   artifactsPath:
     required: false
     default: 'artifacts'
-    description: 'Path where test results should be stored.'
+    description: 'Path where test artifacts should be stored.'
   useNetworkHost:
     required: false
     default: false
-    description: 'Initialzes Docker using the network host.'
+    description: 'Initialises Docker using the hosts network.'
   customParameters:
     required: false
-    description: 'Custom parameters to configure the test runner.'
+    description: 'Extra parameters to configure the Unity editor run.'
 outputs:
   artifactsPath:
     description: 'Path where the artifacts are stored'


### PR DESCRIPTION
The added parameters were already supported but weren't listed, resulting in warnings for projects that use those parameters.

Fixes #60

#### Changes

- Add missing parameters to `action.yml` with descriptions and defaults matching [the docs](https://unity-ci.com/docs/github/test-runner).

#### Checklist

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (not needed)
- [x] Tests (not needed)
